### PR TITLE
Feature/update skll

### DIFF
--- a/discourseparsing/collapse_rst_labels.py
+++ b/discourseparsing/collapse_rst_labels.py
@@ -115,7 +115,7 @@ def main():
             tree = ParentedTree.fromstring(input_file.read().strip())
             reformat_rst_tree(tree)
             collapse_rst_labels(tree)
-            print(tree.pprint(TREE_PRINT_MARGIN), file=output_file)
+            tree.pprint(margin=TREE_PRINT_MARGIN, file=output_file)
 
 
 if __name__ == '__main__':

--- a/discourseparsing/convert_rst_discourse_tb.py
+++ b/discourseparsing/convert_rst_discourse_tb.py
@@ -390,7 +390,7 @@ def main():
                     in enumerate(zip(edus, edu_tokens)):
                 edu_nospace = re.sub(r'\s+', '', edu).lower()
                 edu_tokens_nospace = ''.join(edu_token_list).lower()
-                distance = nltk.metrics.distance.edit_distance(
+                distance = nltk.distance.edit_distance(
                     edu_nospace, edu_tokens_nospace)
                 if distance > 4:
                     logging.warning(("EDIT DISTANCE > 3 IN {}: " +

--- a/discourseparsing/convert_rst_discourse_tb.py
+++ b/discourseparsing/convert_rst_discourse_tb.py
@@ -369,7 +369,7 @@ def main():
                       "path_basename": path_basename,
                       "tokens": tokens_doc,
                       "edu_strings": edus,
-                      "syntax_trees": [t.pprint(margin=TREE_PRINT_MARGIN)
+                      "syntax_trees": [t.pformat(margin=TREE_PRINT_MARGIN)
                                        for t in trees],
                       "token_tree_positions": [[x.treeposition() for x in
                                                 preterminals_sentence]
@@ -378,7 +378,7 @@ def main():
                       "pos_tags": [[x.label() for x in preterminals_sentence]
                                    for preterminals_sentence in preterminals],
                       "edu_start_indices": edu_start_indices,
-                      "rst_tree": rst_tree.pprint(margin=TREE_PRINT_MARGIN),
+                      "rst_tree": rst_tree.pformat(margin=TREE_PRINT_MARGIN),
                       "edu_starts_paragraph": edu_starts_paragraph}
 
             assert len(edu_start_indices) == len(edus)

--- a/discourseparsing/discourse_parsing.py
+++ b/discourseparsing/discourse_parsing.py
@@ -591,7 +591,7 @@ class Parser(object):
                 assert tree.label() == 'ROOT'
 
                 # collapse binary branching * rules in the output
-                output_tree = ParentedTree.fromstring(tree.pprint())
+                output_tree = ParentedTree.fromstring(tree.pformat())
                 collapse_binarized_nodes(output_tree)
 
                 completetrees.append({"tree": output_tree,

--- a/discourseparsing/parse_util.py
+++ b/discourseparsing/parse_util.py
@@ -104,7 +104,7 @@ class SyntaxParserWrapper():
                 logging.warning('The syntactic parser was unable to parse: ' +
                                 '{}, doc_id = {}'.format(sentence, doc_id))
         logging.debug('syntax parsing results: {}'.format(
-            [t.pprint(margin=TREE_PRINT_MARGIN) for t in res]))
+            [t.pformat(margin=TREE_PRINT_MARGIN) for t in res]))
 
         return res
 
@@ -120,7 +120,7 @@ class SyntaxParserWrapper():
                 logging.warning('The syntactic parser was unable to parse: ' +
                                 '{}, doc_id = {}'.format(sentence, doc_id))
         logging.debug('syntax parsing results: {}'.format(
-            [t.pprint(margin=TREE_PRINT_MARGIN) for t in res]))
+            [t.pformat(margin=TREE_PRINT_MARGIN) for t in res]))
 
         return res
 

--- a/discourseparsing/reformat_rst_trees.py
+++ b/discourseparsing/reformat_rst_trees.py
@@ -82,7 +82,7 @@ def reformat_rst_tree(input_tree):
     Treebank tree.
     '''
     logging.debug('Reformatting {}'.format(
-        input_tree.pprint(margin=TREE_PRINT_MARGIN)))
+        input_tree.pformat(margin=TREE_PRINT_MARGIN)))
 
     # 1. rename the top node
     input_tree.set_label('ROOT')
@@ -99,7 +99,7 @@ def reformat_rst_tree(input_tree):
     _replace_edu_strings(input_tree)
 
     logging.debug('Reformatted: {}'.format(
-        input_tree.pprint(margin=TREE_PRINT_MARGIN)))
+        input_tree.pformat(margin=TREE_PRINT_MARGIN)))
 
 
 def main():
@@ -122,7 +122,7 @@ def main():
         rst_tree_str = convert_parens_in_rst_tree_str(rst_tree_str)
         t = ParentedTree.fromstring(rst_tree_str)
         reformat_rst_tree(t)
-        print(t.pprint(margin=TREE_PRINT_MARGIN))
+        t.pprint(margin=TREE_PRINT_MARGIN)
 
 
 if __name__ == '__main__':

--- a/discourseparsing/rst_parse.py
+++ b/discourseparsing/rst_parse.py
@@ -34,7 +34,7 @@ def segment_and_parse(doc_dict, syntax_parser, segmenter, rst_parser):
         # Do syntactic parsing.
         trees, starts_paragraph_list = \
             syntax_parser.parse_document(doc_dict)
-        doc_dict['syntax_trees'] = [t.pprint(margin=TREE_PRINT_MARGIN)
+        doc_dict['syntax_trees'] = [t.pformat(margin=TREE_PRINT_MARGIN)
                                     for t in trees]
         preterminals = [extract_preterminals(t) for t in trees]
         doc_dict['token_tree_positions'] = [[x.treeposition() for x in
@@ -135,7 +135,7 @@ def main():
         print(json.dumps({"edu_tokens": edu_tokens, \
             "scored_rst_trees": [{"score": tree["score"],
                                   "tree": tree["tree"]
-                                          .pprint(margin=TREE_PRINT_MARGIN)}
+                                          .pformat(margin=TREE_PRINT_MARGIN)}
                                  for tree in complete_trees]}))
 
 

--- a/discourseparsing/rst_parse.py
+++ b/discourseparsing/rst_parse.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 # License: MIT
 
+import codecs
 import logging
 import json
+import os
 
 from discourseparsing.discourse_parsing import Parser
 from discourseparsing.discourse_segmentation import (Segmenter,
@@ -132,11 +134,18 @@ def main():
         edu_tokens, complete_trees = segment_and_parse(doc_dict, syntax_parser,
                                                        segmenter, parser)
 
+        complete_trees = [tree for tree in complete_trees]  # can't use a generator twice
+
         print(json.dumps({"edu_tokens": edu_tokens, \
             "scored_rst_trees": [{"score": tree["score"],
                                   "tree": tree["tree"]
                                           .pformat(margin=TREE_PRINT_MARGIN)}
                                  for tree in complete_trees]}))
+
+        for i, tree in enumerate(complete_trees, 1):
+            ptree_str = tree['tree'].__repr__() + '\n'
+            with codecs.open(input_path + '_{}.parentedtree'.format(str(i)), 'w', 'utf-8') as ptree_file:
+                ptree_file.write(ptree_str)
 
 
 if __name__ == '__main__':

--- a/discourseparsing/rst_parse_batch.py
+++ b/discourseparsing/rst_parse_batch.py
@@ -34,7 +34,7 @@ def batch_process(docs, output_path, zpar_model_directory,
             print(json.dumps({"doc_id": doc_id, "edu_tokens": edu_tokens, \
                 "scored_rst_trees": \
                 [{"score": tree["score"],
-                  "tree": tree["tree"].pprint(margin=TREE_PRINT_MARGIN)}
+                  "tree": tree["tree"].pformat(margin=TREE_PRINT_MARGIN)}
                  for tree in complete_trees]}), file=outfile)
 
 

--- a/discourseparsing/segment_document.py
+++ b/discourseparsing/segment_document.py
@@ -48,7 +48,7 @@ def main():
                 for preterminals_sentence in preterminals]
 
     doc_dict["tokens"] = tokens_doc
-    doc_dict["syntax_trees"] = [t.pprint(TREE_PRINT_MARGIN) for t in trees]
+    doc_dict["syntax_trees"] = [t.pformat(margin=TREE_PRINT_MARGIN) for t in trees]
     doc_dict["token_tree_positions"] = token_tree_positions
     doc_dict["pos_tags"] = pos_tags
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.9.2
-nltk==3.0.0
+nltk==3.2.1
 scikit-learn==0.15.2
 scipy==0.15.1
 cchardet>=0.3.5

--- a/tests/try_head_rules.py
+++ b/tests/try_head_rules.py
@@ -32,7 +32,7 @@ def main():
 
         for t in trees:
             convert_ptb_tree(t)
-            print("\n\n{}".format(t.pprint()))
+            print("\n\n{}".format(t.pformat()))
             for subtree in t.subtrees():
                 print("{}{}\t{}".format(' '.join(['' for x in range(depth(subtree))]), subtree.label(), subtree.head_word()))
 


### PR DESCRIPTION
Hi,

I ran into a number of problems when I tried get the parser running, so I made some changes.
With these changes, the software will run on Python 3.5, nltk 3.2.1 and skll 1.0.1.

I verified that the RST parser installs, trains and runs by creating docker containers
(cf. https://github.com/NLPbox/heilman-sagae-2015-docker).
If someone wants to run the parser with a pre-trained RST-DT model, all they would
have to do is type one command:

```
docker run -ti nlpbox/heilman-sagae-2015:trained
```

This will download, install and run the discourse parser on a test file,
all in one go.

To run it on a file in your current directory, mount that directory into the docker container
(with the ``-v`` option) and point the parser to the mounted file, e.g.

```
$ cat input.txt 
Although they didn't like it, they accepted the offer.

$ docker run -v $(pwd):/opt/discourse-parser -ti nlpbox/heilman-sagae-2015:trained /opt/discourse-parser/input.txt
Loading tagger from /opt/zpar-0.7/models/english/tagger
Loading model... done.
Loading constituency parser from /opt/zpar-0.7/models/english/conparser
Loading scores... done. (30.1611s)
{"edu_tokens": [["Although", "they", "did", "n't", "like", "it", ","], ["they", "accepted", "the", "offer", "."]], "scored_rst_trees": [{"tree": "(ROOT (satellite:contrast (text 0)) (nucleus:span (text 1)))", "score": -0.9662282971887425}]}
```

Best,
Arne