### PR TITLE
v1.0 Release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE.txt
+recursive-include rstfinder/utils/ *.js *.html *.txt

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ RSTFinder is trained using [RST Discourse Treebank](https://catalog.ldc.upenn.ed
 3. **Create a development set**. Split the documents in the RST discourse treebank training set into a new training and development set:
 
     ```bash
-    make_traindev_split.py
+    make_traindev_split
     ```
 
     At the end of this command, you will have the following JSON files in your current directory:

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ RSTFinder is trained using [RST Discourse Treebank](https://catalog.ldc.upenn.ed
     conda activate rstenv
     ```
 
-2. **Download NLTK tagger model**. Due to a rare mismatch between the RST Discourse Treebank and the Penn Treebank documents, sometimes there are parts of the document for which we cannot locate the corresponding parse trees. To get around this issue, we first part-of-speech tag such parts using the MaxEnt POS tagger model from NLTK and then just create fake, shallow trees for them. Therefore, we need to download this tagger model.
+2. **Download NLTK tagger model**. Due to a rare mismatch between the RST Discourse Treebank and the Penn Treebank documents, sometimes there are parts of the document for which we cannot locate the corresponding parse trees. To get around this issue, we first sentence-tokenize & part-of-speech tag such parts using the MaxEnt POS tagger model from NLTK and, then, just create fake, shallow trees for them. Therefore, we need to download tokenizer and tagger models for this.
 
     ```bash
     export NLTK_DATA="$HOME/nltk_data"
-    python -m nltk.downloader maxent_treebank_pos_tagger
+    python -m nltk.downloader maxent_treebank_pos_tagger punkt
     ```
 
 2. **Pre-process and merge the treebanks**. To create a merged dataset that contains the RST Discourse Treebank along with the corresponding Penn Treebank parse trees for the same documents, run the following command (with paths adjusted as appropriate):

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Travis CI Badge](https://img.shields.io/travis/EducationalTestingService/rstfinder)
+![Travis CI Badge](https://img.shields.io/travis/EducationalTestingService/rstfinder) ![Conda Package](https://img.shields.io/conda/v/ets/rstfinder.svg) ![Conda Platform](https://img.shields.io/conda/pn/ets/rstfinder.svg) ![License](https://img.shields.io/github/license/EducationalTestingService/rstfinder)
 
 ## Table of Contents
 
@@ -16,21 +16,27 @@ This repository contains the code for **RSTFinder** -- a discourse segmenter & s
 
 ## Installation
 
-RSTFinder currently works only on Linux and requires Python 3.6. Support for other platforms (Windows, macOS) and for Python versions 3.7 and higher is in the works.
+RSTFinder currently works only on Linux and requires Python 3.6, 3.7, or 3.8. 
 
 The only way to install RSTFinder is by using the `conda` package manager. If you have already installed `conda`, you can skip straight to Step 2.
 
 1. To install `conda`, follow the instructions on [this page](https://conda.io/projects/conda/en/latest/user-guide/install/index.html). 
 
-2. Create a new conda environment (say, `rstenv`) and install the RSTFinder conda package.
+2. Create a new conda environment (say, `rstenv`) and install the RSTFinder conda package in it.
 
-    ```
-    conda create -n rstenv -c conda-forge -c ets python=3.6 rstfinder
+    ```bash
+    conda create -n rstenv -c conda-forge -c ets python=3.8 rstfinder
     ```
 
 3. Activate this conda environment by running `conda activate rstfinder`. 
 
-4. From now on, you will need to activate this conda environment whenever you want to use RSTFinder. This will ensure that the packages required by RSTFinder will not affect other projects.
+4. Now install the `python-zpar` package via `pip` in this environment. This package allows us to use the ZPar constituency parser (more later).
+
+    ```bash
+    pip install python-zpar
+    ```
+
+5. From now on, you will need to activate this conda environment whenever you want to use RSTFinder. This will ensure that the packages required by RSTFinder will not affect other projects.
 
 ## Usage
 

--- a/conda-recipe/rstfinder/meta.yaml
+++ b/conda-recipe/rstfinder/meta.yaml
@@ -1,0 +1,46 @@
+package:
+  name: rstfinder
+  version: 1.0
+
+source:
+  path: ../../ 
+
+build:
+  number: 0
+  script:
+    - cd $SRC_DIR
+    - "{{ PYTHON }} -m pip install . --no-deps -vv"
+  entry_points:
+    - segment_document = rstfinder.segment_document:main
+    - tune_segmentation_model = rstfinder.tune_segmentation_model:main
+    - rst_parse = rstfinder.rst_parse:main
+    - tune_rst_parser = rstfinder.tune_rst_parser:main
+    - convert_rst_discourse_tb = rstfinder.convert_rst_discourse_tb:main
+    - make_traindev_split = rstfinder.make_traindev_split:main
+    - rst_eval = rstfinder.rst_eval:main
+    - extract_segmentation_features = rstfinder.extract_segmentation_features:main
+    - rst_parse_batch = rstfinder.rst_parse_batch:main
+    - compute_bootstrap_from_predictions = rstfinder.utils.compute_bootstrap_from_predictions:main
+    - try_head_rules = rstfinder.utils.try_head_rules:main
+    - visualize_rst_tree = rstfinder.utils.visualize_rst_tree:main
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - pip
+    - numpy
+    - nltk
+    - cchardet
+    - crfpp==0.59
+    - skll
+    - jinja2
+    - scikits-bootstrap
+
+about:
+  home: http://github.com/EducationalTestingService/rstfinder
+  license: MIT
+  license_file: LICENSE.txt
+  summary: Fast Discourse Parser to find latent Rhetorical STructure (RST) in text.

--- a/rstfinder/__init__.py
+++ b/rstfinder/__init__.py
@@ -1,3 +1,9 @@
 # Ensure there won't be logging complaints about no handlers being set
 import logging
+
 logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+try:
+    import zpar
+except ImportError:
+    raise ImportError("The 'python-zpar' package is missing. Run 'pip install python-zpar' to install it.") from None

--- a/rstfinder/version.py
+++ b/rstfinder/version.py
@@ -1,0 +1,11 @@
+# License: BSD 3 clause
+"""
+This module exists solely for version information so I only have to change it
+in one place. Based on the suggestion `here. <http://bit.ly/16LbuJF>`_
+
+:author: Nitin Madnani (nmadnani@ets.org)
+:organization: ETS
+"""
+
+__version__ = '1.0.0'
+VERSION = tuple(int(x) for x in __version__.split('.'))

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,10 @@
 
 from setuptools import find_packages, setup
 
+# Get version without importing, which avoids dependency issues
+exec(compile(open('rstfinder/version.py').read(), 'rstfinder/version.py', 'exec'))
+# (we use the above instead of execfile for Python 3.x compatibility)
+
 
 def readme():
     with open('README.md') as f:
@@ -13,7 +17,7 @@ def requirements():
 
 
 setup(name='rstfinder',
-      version='0.2.1',
+      version=__version__,
       description=('A discourse parser and segmenter for use with the '
                    'Rhetorical Structure Theory Discourse Treebank '
                    '(https://catalog.ldc.upenn.edu/LDC2002T07).'),
@@ -25,6 +29,7 @@ setup(name='rstfinder',
       maintainer_email='nmadnani@ets.org',
       license='MIT',
       packages=find_packages(exclude=['tests']),
+      include_package_data=True,
       entry_points={'console_scripts': ['segment_document = rstfinder.segment_document:main',
                                         'tune_segmentation_model = rstfinder.tune_segmentation_model:main',
                                         'rst_parse = rstfinder.rst_parse:main',


### PR DESCRIPTION
- Add `version.py` and use that in `setup.py`. Update version to 1.0.
- Update README to include installation instructions and more badges.
- Update `MANIFEST.in` file to include non-Python files that are required.
- Add conda recipe.
- Add check for `python-zpar` when importing rstfinder. This is to make sure that users do not forget to install `python-zpar` since we cannot include it as a conda requirement.

The conda package has been built and is already [live](https://anaconda.org/ets/rstfinder) for Python 3.6, 3.7. and 3.8.  