### PR TITLE
Another fix for skll 3

### DIFF
--- a/.ci_support/3.10.yaml
+++ b/.ci_support/3.10.yaml
@@ -1,0 +1,17 @@
+channels:
+  - conda-forge
+  - ets
+dependencies:
+  - python=3.10
+  - pip
+  - numpy
+  - nltk
+  - cchardet
+  - crfpp==0.59
+  - skll>=2.5
+  - jinja2
+  - scikits-bootstrap
+  - nose
+  - coverage
+  - pip:
+    - python-zpar

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,3 +41,10 @@ test-3.9:
     PYVERSION: "3.9"
   stage: "test"
 
+# python 3.10 tests
+test-3.10:
+  extends: ".runtest"
+  variables:
+    PYVERSION: "3.10"
+  stage: "test"
+

--- a/rstfinder/tune_rst_parser.py
+++ b/rstfinder/tune_rst_parser.py
@@ -131,6 +131,9 @@ def prune_model(model_path, model_name):
     nonzero_feat_mask = ~np.all(model.model.coef_ == 0, axis=0)
     model.model.coef_ = model.model.coef_[:, nonzero_feat_mask]
 
+    # update `n_features_in_` attribute of the LogisticRegression estimator
+    model.model.n_features_in_ = model.model.coef_.shape[1]
+
     # remove the extra words from the feature vectorizer
     model.feat_vectorizer.restrict(nonzero_feat_mask)
 


### PR DESCRIPTION
Changes: 

- Patch `n_features_in_` attribute of underlying scikit-learn model when pruning. This attribute was added in scikit-learn 0.24 but is used to validate incoming data at inference time only starting with scikit-learn 1.0. Therefore, this is only a problem with SKLL 3.0 and not with SKLL 2.5.

- Add gitlab CI build for Python 3.10 since there’s no reason we shouldn’t support that as well. 